### PR TITLE
fix (LanguageProvider): fixed persistence of language change

### DIFF
--- a/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useLanguageContext } from 'context/Language/useLanguageContext'
-import { languageOptions } from 'context/Language/langConfig'
+import { languageOptions } from 'context/Language/language.data'
 import Select from 'ui/Select/Select'
 
 const LanguageSwitcher: React.FC = () => {

--- a/src/context/Language/LanguageContext.tsx
+++ b/src/context/Language/LanguageContext.tsx
@@ -1,85 +1,46 @@
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useState } from 'react'
+
 import useLocalStorage from 'hooks/useLocalStorage'
 import en from 'lang/en.json'
 import es from 'lang/es.json'
-import fr from 'lang/fr.json'
-import pt from 'lang/pt.json'
+// import fr from 'lang/fr.json'
+// import pt from 'lang/pt.json'
+import { LANGUAGE_LOCAL_STORAGE_KEY } from './constants'
 import {
-  ENGLISH,
-  ESPANOL,
-  FRANCAIS,
-  PORTUGUES,
-  LANGUAGE_LOCAL_STORAGE_KEY,
-} from './constants'
+  ILanguageDefinition,
+  ILangaugeContextProps,
+  ILanguageProviderProps,
+} from 'types/context/languageContext'
 
-interface LanguageDefinition {
-  locale: string
-  messages: { [index: string]: string }
+const getLanguageData = (key: string): ILanguageDefinition => {
+  switch (key) {
+    case 'es':
+      return { locale: 'es', messages: es }
+    case 'en':
+      return { locale: 'en', messages: en }
+    default:
+      return { locale: 'en', messages: en }
+  }
 }
 
-interface LangaugeContextProps {
-  language: LanguageDefinition
-  handleLanguage: (value: string) => void
-}
-
-interface LanguageProviderProps {
-  children: React.ReactNode
-}
-
-const LanguageContext = createContext<LangaugeContextProps>(
-  {} as LangaugeContextProps
+const LanguageContext = createContext<ILangaugeContextProps>(
+  {} as ILangaugeContextProps
 )
 
-const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) => {
-  const [storageLanguage, setStorageLanguage] = useLocalStorage<string>(
+const LanguageProvider: React.FC<ILanguageProviderProps> = ({ children }) => {
+  const [storageValue, setStorageValue] = useLocalStorage<string>(
     LANGUAGE_LOCAL_STORAGE_KEY,
     'en'
   )
 
-  const [language, setLanguage] = useState<LanguageDefinition>({
-    locale: 'en',
-    messages: en,
-  })
-
-  useEffect(() => {
-    if (storageLanguage) {
-      handleLanguage(storageLanguage)
-    }
-  }, [storageLanguage])
+  const [language, setLanguage] = useState<ILanguageDefinition>(
+    getLanguageData(storageValue)
+  )
 
   const handleLanguage = (value: string) => {
-    switch (value) {
-      case ESPANOL:
-        setStorageLanguage('es')
-        setLanguage({
-          locale: 'es',
-          messages: es,
-        })
-        break
-      case ENGLISH:
-        setStorageLanguage('en')
-        setLanguage({
-          locale: 'en',
-          messages: en,
-        })
-        break
-      case PORTUGUES:
-        setStorageLanguage('pt')
-        setLanguage({
-          locale: 'pt',
-          messages: pt,
-        })
-        break
-      case FRANCAIS:
-        setStorageLanguage('fr')
-        setLanguage({
-          locale: 'fr',
-          messages: fr,
-        })
-        break
-      default:
-        break
-    }
+    const lang = value.toLowerCase()
+    setStorageValue(lang)
+    setLanguage(getLanguageData(lang))
   }
 
   return (

--- a/src/context/Language/language.data.ts
+++ b/src/context/Language/language.data.ts
@@ -1,12 +1,7 @@
 import { ENGLISH, ESPANOL } from './constants'
+import { ILanguage } from 'types/context/languageContext'
 
-export interface ILanguagaConfiguration {
-  id: string
-  value: string
-  name: string
-}
-
-export const languageOptions: ILanguagaConfiguration[] = [
+export const languageOptions: ILanguage[] = [
   {
     id: 'en',
     value: ENGLISH,

--- a/src/types/context/languageContext.ts
+++ b/src/types/context/languageContext.ts
@@ -1,0 +1,19 @@
+import { PropsWithChildren } from 'react'
+
+export interface ILanguage {
+  id: string
+  value: string
+  name: string
+}
+
+export interface ILanguageDefinition {
+  locale: string
+  messages: { [key: string]: string }
+}
+
+export interface ILangaugeContextProps {
+  language: ILanguageDefinition
+  handleLanguage: (value: string) => void
+}
+
+export interface ILanguageProviderProps extends PropsWithChildren {}


### PR DESCRIPTION
## Summary
### **Issue**: 
The web page doesn't remain with the `selected language` change when updating.
### **Solution**: 
Update the `initial state` of the `LanguageProvider` with that of the `Local Storage` (If there is no data it is initialized with the English language) and update both when the user changes the language.