### PR TITLE
feat: set default language using browser language

### DIFF
--- a/src/context/Language/LanguageContext.tsx
+++ b/src/context/Language/LanguageContext.tsx
@@ -11,6 +11,7 @@ import {
   ILanguageContextProps,
   ILanguageProviderProps,
 } from 'types/context/languageContext'
+import useNavigatorLanguage from 'hooks/useNavigatorLanguage'
 
 const getLanguageData = (key: string): ILanguageDefinition => {
   switch (key) {
@@ -28,9 +29,10 @@ const LanguageContext = createContext<ILanguageContextProps>(
 )
 
 const LanguageProvider: React.FC<ILanguageProviderProps> = ({ children }) => {
+  const navLanguage = useNavigatorLanguage()
   const [storageValue, setStorageValue] = useLocalStorage<string>(
     LANGUAGE_LOCAL_STORAGE_KEY,
-    'en'
+    navLanguage
   )
   const [language, setLanguage] = useState<ILanguageDefinition>(() =>
     getLanguageData(storageValue)

--- a/src/hooks/useNavigatorLanguage.tsx
+++ b/src/hooks/useNavigatorLanguage.tsx
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react'
+
+const langSubscribe = (callback: () => void) => {
+  window.addEventListener('languagechange', callback)
+  return () => window.removeEventListener('languagechange', callback)
+}
+
+const getLang = () => navigator.language.split('-')[0]
+
+/**
+ * Hook that gets the current language used by the browser.
+ * 
+ * @returns string Language: 2-letter format without its regional variations.
+ * 
+ * @example
+ * ```ts
+ * import useNavigatorLanguage from '@/hooks/useNavigatorLanguage';
+ * 
+ * const navLanguage = useNavigatorLanguage()
+ * console.log(navLanguage)
+ * ```
+ */
+
+export const useNavigatorLanguage = (): string =>
+  useSyncExternalStore(langSubscribe, getLang)
+
+export default useNavigatorLanguage


### PR DESCRIPTION
# Set default language using browser language

## Summary
To get and update the browser language to react, the [useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore#subscribing-to-an-external-store) hook was used as well as the [languagechange](https://developer.mozilla.org/en-US/docs/Web/API/Window/languagechange_event) event of the window instance.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [ ] Chore

## Checklist:

These items must be completed before the code review

- [ ] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [ ] Check task requirements on Monday or Sprint Planning sheet

## Screenshots or Gifs
### English: en
![browser-en](https://github.com/user-attachments/assets/48497422-63ac-4656-9d3f-347becda506b)
![site-eng](https://github.com/user-attachments/assets/969fac51-9184-44b4-b395-e1a23415c22b)

### Spanish: es
![browser-es](https://github.com/user-attachments/assets/aeea2f3d-1961-457e-8886-3cb070a4d478)
![site-es](https://github.com/user-attachments/assets/9557fa59-cfb2-4e03-b6b8-a0e828c4150a)