### PR TITLE
fix (page not found): reduce unnecessary height

### DIFF
--- a/src/pages/PageNotFound/PageNotFound.style.ts
+++ b/src/pages/PageNotFound/PageNotFound.style.ts
@@ -9,10 +9,12 @@ export const StyledPageNotFound = styled(Container)`
   flex-grow: 1;
   align-items: center;
   gap: 3rem;
-  height: calc(100vh - 4.5rem);
+  min-height: calc(100dvh - var(--header-height));
 
   .not-found-img {
+    aspect-ratio: 348 / 209;
     width: 100%;
+    height: 100%;
   }
 
   .button-not-found {


### PR DESCRIPTION
# Reduce unnecessary height of the Page Not Found

## Summary
This page has excessive height.

### Problem
Lack of dynamic height on this page, with no min-height and excessive image height

### Cause
Lack of dynamic height on this page, with no min-height and excessive image height.

### Solution

- Add a dynamic height with `dvh`.
- Change `height` to `min-heigth`, keeping the assigned values.
- Add an `aspect-radius` to the image and make its `height` 100%.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [x] Styling
- [ ] Testing
- [ ] Chore
- [ ] Other: ...

## Checklist:

These items must be completed before the code review

- [x] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [x] Check task requirements on Monday or Sprint Planning sheet
