### PR TITLE
feat (faqcard): add animation to display question

### DIFF
--- a/src/components/FaqCard/FaqCard.styles.ts
+++ b/src/components/FaqCard/FaqCard.styles.ts
@@ -1,17 +1,21 @@
 import styled from 'styled-components'
+import { motion } from 'framer-motion'
 
 import { breakpoints } from 'shared/breakpoints'
 import { colors } from 'styles/colors'
 
 export const QuestionWrapper = styled.div`
   width: 100%;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  background-color: ${colors.tertiary.normal[50]};
 `
 
 export const Question = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-radius: 0.5rem;
+  border-radius: 0 0 0.5rem 0.5rem;
   color: ${colors.black.main};
   background-color: ${colors.tertiary.normal[50]};
   font-size: clamp(0.8rem, 4vw, 1.125rem);
@@ -19,15 +23,16 @@ export const Question = styled.div`
   font-weight: 400;
   padding: 0.75rem 1.5rem;
   gap: 1rem;
+  transition: border-radius .8s ease;
 
-  @media only screen and (min-width: ${breakpoints.lg}) {
+  @media only screen and (min-width: ${breakpoints.sm}) {
     padding: 1.5rem 3rem;
   }
 
   &.selected {
     background-color: ${colors.tertiary.normal[200]};
     color: ${colors.black.main};
-    border-radius: 0.5rem 0.5rem 0 0;
+    border-radius: 0;
   }
 
   &:hover,
@@ -54,17 +59,16 @@ export const Question = styled.div`
   }
 `
 
-export const FAQAnswer = styled.div`
-  border-radius: 0 0 0.5rem 0.5rem;
-  padding: 2rem;
-  background-color: ${colors.tertiary.normal[50]};
-
+export const FAQAnswer = styled(motion.div)`
+  overflow: hidden;
+  
   & .faq-answer {
     color: ${colors.black.main};
     font-size: clamp(0.8rem, 4vw, 1rem);
-  }
+    padding: 32px;
 
-  @media only screen and (min-width: ${breakpoints.lg}) {
-    padding: 3rem;
+    @media only screen and (min-width: ${breakpoints.lg}) {
+      padding: 3rem;
+    }
   }
 `

--- a/src/components/FaqCard/FaqCard.styles.ts
+++ b/src/components/FaqCard/FaqCard.styles.ts
@@ -65,7 +65,7 @@ export const FAQAnswer = styled(motion.div)`
   & .faq-answer {
     color: ${colors.black.main};
     font-size: clamp(0.8rem, 4vw, 1rem);
-    padding: 32px;
+    padding: 2rem;
 
     @media only screen and (min-width: ${breakpoints.lg}) {
       padding: 3rem;

--- a/src/components/FaqCard/FaqCard.tsx
+++ b/src/components/FaqCard/FaqCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { IoMdAdd } from 'react-icons/io'
-import { IoIosRemove } from 'react-icons/io'
+import { IoMdAdd, IoIosRemove } from 'react-icons/io'
+import { AnimatePresence } from 'framer-motion'
 
 import { FAQAnswer, Question, QuestionWrapper } from './FaqCard.styles'
 
@@ -24,11 +24,18 @@ const FaqCard: React.FC<IFaqCardProps> = ({ question, answer }) => {
           {showAnswer && <IoIosRemove size={22} />}
         </div>
       </Question>
-      {showAnswer && (
-        <FAQAnswer>
-          <p className="faq-answer">{answer}</p>
-        </FAQAnswer>
-      )}
+      <AnimatePresence>
+        {showAnswer && (
+          <FAQAnswer
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: .5 }}
+          >
+            <p className="faq-answer">{answer}</p>
+          </FAQAnswer>
+        )}
+      </AnimatePresence>
     </QuestionWrapper>
   )
 }


### PR DESCRIPTION
# Add animation to display questions on FAQ Page

## Summary
Add a smooth animation when displaying the question content on the FAQ page using the Framer Motion library, as it supports adding styles to components that mount and unmount based on conditions.

### Solution
Use the [`<AnimatePresence/>`](https://www.framer.com/motion/animate-presence/) component from Framer Motion to animate `opacity` and `height`, as well as reorganize some CSS attributes to avoid conflicts with Framer Motion animations, such as `padding` in `<FAQAnswer/>`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [x] Styling
- [ ] Testing
- [ ] Chore
- [ ] Other: ...

## Checklist:

These items must be completed before the code review

- [x] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [x] Check task requirements on Monday or Sprint Planning sheet
