### PR TITLE
chore: trim description metadata for all pages

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -128,7 +128,7 @@
 	"home.clients.section.title": "Who trust on us",
 	"home.clients.section.button": "See more",
 
-	"about.us.title": "About us",
+	"about.us.title.tag": "About us",
 	"about.us.quote.description": "Everything is posible!",
 	"about.us.binland.information.sub.title": "Something to mention",
 	"about.us.binland.information.title": "about us",
@@ -173,7 +173,7 @@
 	"about.us.offices.sub.title.collage": "Our team supports us",
 	"about.us.offices.title.collage": "The foundations of good projects are here",
 
-	"contact.us.tab.title": "Contact Us",
+	"contact.us.title.tag": "Contact Us",
 	"contact.us.hero.title": "Contact Us",
 	"contact.us.hero.description": "Were here for you. Reach out using the form belowa",
 	"contact.us.calendly.button": "Schedule a meeting",
@@ -220,6 +220,7 @@
 
 	"services.hero.title": "Services",
 
+	"frequently.asked.questions.title.tag": "Frequently asked questions",
 	"frequently.asked.questions.title": "Frequently asked questions",
 	"frequently.asked.questions.still.have.questions": "Still have questions?",
 	"frequently.asked.questions.still.have.questions.description": "Can't find the answer you're looking for? Please contact our friendly team",
@@ -234,7 +235,8 @@
 	"faq.question.data.security": "How do you ensure the security and confidentiality of client data during development?",
 	"faq.answer.data.security": "The security and confidentiality of our clients' data are our top priorities. We implement state-of-the-art security practices, such as data encryption, restricted access, and regular audits.",
 
-	"terms.of.services.title": "Terms of service",
+	"terms.of.service.title.tag": "Terms of service",
+	"terms.of.service.title": "Terms of service",
 
 	"footer.logotipo.aria.label": "Go to the home page Binland",
 	"footer.all.rights.reserved": "All rights reserved",
@@ -261,10 +263,13 @@
 	"contact.us.form.toast.success": "Sent successfully",
 	"contact.us.form.toast.error": "Error, try again",
 
+	"page.not.found..title.tag": "Page not found",
 	"page.not.found.tab.title": "Page not found",
 	"page.not.found.title": "Oops!",
 	"page.not.found.sub.title": "I think you got lost...",
 	"page.not.found.button.to.home": "Return to Home",
+
+	"privacy.policy.title.tag": "Privacy policy",
 
 	"image.profile.alt.crhistian.turpo.apaza": "Image of the company's CEO, Crhistian Turpo",
 	"image.profile.alt.jonathan.cervantes.alarcon": "Image of one of the founders, Jonathan Cervantes",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -128,7 +128,7 @@
 	"home.clients.section.title": "Quienes confían en nosotros",
 	"home.clients.section.button": "Ver más",
 
-	"about.us.title": "Nosotros",
+	"about.us.title.tag": "Nosotros",
 	"about.us.quote.description": "¡Todo es posible!",
 	"about.us.binland.information.sub.title": "Algo que mencionar",
 	"about.us.binland.information.title": "sobre nosotros",
@@ -173,7 +173,7 @@
 	"about.us.offices.sub.title.collage": "Nuestro equipo nos respalda",
 	"about.us.offices.title.collage": "Los cimientos de buenos proyectos estan aqui",
 
-	"contact.us.tab.title": "Contáctanos",
+	"contact.us.title.tag": "Contáctanos",
 	"contact.us.hero.title": "Contáctanos",
 	"contact.us.hero.description": "Estamos aquí por tí. Comuníquese usando el siguiente formulario",
 	"contact.us.calendly.button": "Agenda tu reunión",
@@ -220,6 +220,7 @@
 
 	"services.hero.title": "Servicios",
 
+	"frequently.asked.questions.title.tag": "Preguntas frecuentes",
 	"frequently.asked.questions.title": "Preguntas frecuentes",
 	"frequently.asked.questions.still.have.questions": "¿Todavía tienes preguntas?",
 	"frequently.asked.questions.still.have.questions.description": "¿No encuentras la respuesta que buscas? Por favor comunicate con nuestro equipo amigable",
@@ -234,7 +235,8 @@
 	"faq.question.data.security": "¿Cómo garantizan la seguridad y la confidencialidad de los datos del cliente durante el desarrollo?",
 	"faq.answer.data.security": "La seguridad y confidencialidad de los datos de nuestros clientes son nuestras prioridades. Implementamos prácticas de seguridad de última generación, como encriptación de datos, acceso restringido y auditorías regulares.",
 
-	"terms.of.services.title": "Terminos de servicio",
+	"terms.of.service.title.tag": "Términos de servicio",
+	"terms.of.service.title": "Terminos de servicio",
 
 	"footer.logotipo.aria.label": "Ir a la pagina Inicio de Binland",
 	"footer.all.rights.reserved": "Todos los derechos reservados",
@@ -261,10 +263,13 @@
 	"contact.us.form.toast.success": "Enviado con éxito",
 	"contact.us.form.toast.error": "Error, intenta otra vez",
 
+	"page.not.found.title.tag": "Página no encontrada",
 	"page.not.found.tab.title": "Página no encontrada",
 	"page.not.found.title": "Ups!",
 	"page.not.found.sub.title": "Creo que te extraviaste...",
 	"page.not.found.button.to.home": "Regresa al Inicio",
+
+	"privacy.policy.title.tag": "Políticas de privacidad",
 
 	"image.profile.alt.crhistian.turpo.apaza": "Imagen del CEO de la compañia, Crhistian Turpo",
 	"image.profile.alt.jonathan.cervantes.alarcon": "Imagen de uno de los fundadores, Jonathan Cervantes",

--- a/src/pages/AboutUs/AboutUs.tsx
+++ b/src/pages/AboutUs/AboutUs.tsx
@@ -21,15 +21,15 @@ const AboutUs = () => {
 				<meta
 					name="description"
 					lang="en"
-					content="Meet our team of software development experts at Binland. We turn ideas into innovative solutions, providing high-quality, personalized services to drive your business forward. Learn about our mission and vision."
+					content="Meet about our software development team."
 				/>
 				<meta
 					name="description"
 					lang="es"
-					content="Conoce a nuestro equipo de expertos en desarrollo de software. En Binland, transformamos ideas en soluciones innovadoras, ofreciendo servicios personalizados de alta calidad para impulsar tu negocio. Descubre nuestra misión y visión."
+					content="Conoce a nuestro equipo de desarrollo de software."
 				/>
 				<meta property="og:image" content={imageLinkPreview} />
-				<title>Binland - {intl("about.us.title")}</title>
+				<title>{intl("about.us.title.tag")}</title>
 			</Helmet>
 			<Suspense>
 				<Quote />

--- a/src/pages/ContactUs/ContactUs.tsx
+++ b/src/pages/ContactUs/ContactUs.tsx
@@ -27,15 +27,15 @@ const ContactUs: React.FC = () => {
 				<meta
 					name="description"
 					lang="en"
-					content="Have a question or a project in mind? At Binland, we’re ready to help. Contact us to discuss your software development needs and explore how we can work together."
+					content="Have a question or a project in mind?"
 				/>
 				<meta
 					name="description"
 					lang="es"
-					content="¿Tienes alguna pregunta o proyecto en mente? En Binland, estamos listos para ayudarte. Contáctanos para discutir tus necesidades de desarrollo de software y descubrir cómo podemos colaborar."
+					content="¿Tienes alguna pregunta o proyecto en mente?"
 				/>
 				<meta property="og:image" content={imageLinkPreview} />
-				<title>Binland - {intl("contact.us.tab.title")}</title>
+				<title>{intl("contact.us.title.tag")}</title>
 			</Helmet>
 			<ContactUsHero>
 				<SectionTitleHero type="padding" size="lg">

--- a/src/pages/FrequentlyAskedQuestion/FrequentlyAskedQuestion.tsx
+++ b/src/pages/FrequentlyAskedQuestion/FrequentlyAskedQuestion.tsx
@@ -23,15 +23,15 @@ const FrequenltyAskedQuestion = () => {
 				<meta
 					name="description"
 					lang="en"
-					content="Find answers to frequently asked questions about our software development services. At Binland, we address your queries and provide the information you need to make informed decisions. Explore our FAQ section."
+					content="Clarify your most frequently asked questions."
 				/>
 				<meta
 					name="description"
 					lang="es"
-					content="Encuentra respuestas a las preguntas más frecuentes sobre nuestros servicios de desarrollo de software. En Binland, resolvemos tus dudas y te ofrecemos la información que necesitas para tomar decisiones informadas. Explora nuestra sección de preguntas frecuentes."
+					content="Aclara tus dudas mas frecuentes."
 				/>
 				<meta property="og:image" content={imageLinkPreview} />
-				<title>Binland - {intl("frequently.asked.questions.title")}</title>
+				<title>{intl("frequently.asked.questions.title.tag")}</title>
 			</Helmet>
 			<SectionFAQ id="frequently-asked-questions" size="lg" type="margin">
 				<ContainerFaq size="xl">

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -16,12 +16,12 @@ const Home = () => {
 				<meta
 					name="description"
 					lang="en"
-					content="Binland is a software development and design company, specializing in creating innovative digital solutions for businesses. Contact us for custom software, web design, and more."
+					content="Binland is a software development and design company, specializing in creating innovative digital solutions for businesses."
 				/>
 				<meta
 					name="description"
 					lang="es"
-					content="Binland es una empresa de desarrollo de software y diseño, especializada en crear soluciones digitales innovadoras para empresas. Contáctanos para software personalizado, diseño web y más."
+					content="Binland es una empresa de desarrollo de software y diseño, especializada en crear soluciones digitales innovadoras para empresas."
 				/>
 				<meta property="og:image" content={imageLinkPreview} />
 				<title>Binland</title>

--- a/src/pages/PageNotFound/PageNotFound.tsx
+++ b/src/pages/PageNotFound/PageNotFound.tsx
@@ -26,15 +26,15 @@ const PageNotFound = () => {
 				<meta
 					name="description"
 					lang="en"
-					content="Sorry, the page you’re looking for is not available. At Binland, we’re here to help. You can return to the homepage or explore other sections of our site to find the information you need."
+					content="Sorry, the page you're looking for is not available."
 				/>
 				<meta
 					name="description"
 					lang="es"
-					content="Lo sentimos, la página que buscas no está disponible. En Binland, estamos aquí para ayudarte. Puedes volver a la página de inicio o explorar otras secciones de nuestro sitio para encontrar la información que necesitas."
+					content="Lo sentimos, la página que buscas no está disponible."
 				/>
 				<meta property="og:image" content={imageLinkPreview} />
-				<title>Binland - {intl("page.not.found.tab.title")}</title>
+				<title>{intl("page.not.found.title.tag")}</title>
 			</Helmet>
 			<StyledPageNotFound size="xl">
 				<MessageWrapper>

--- a/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,7 +1,31 @@
+import { Helmet } from "react-helmet-async"
+
+import useIntlMessages from "hooks/useIntlMessages"
 import Container from "ui/Container/Container"
+import imageLinkPreview from "../../assets/images/image-link-preview.webp"
 
 const PrivacyPolicy: React.FC = () => {
-	return <Container size="sm">Privacy Policy</Container>
+	const intl = useIntlMessages()
+
+	return (
+		<Container size="sm">
+			<Helmet prioritizeSeoTags>
+				<meta
+					name="description"
+					lang="en"
+					content="Information on the management of personal data."
+				/>
+				<meta
+					name="description"
+					lang="es"
+					content="Información sobre la gestión de datos personales."
+				/>
+				<meta property="og:image" content={imageLinkPreview} />
+				<title>{intl("privacy.policy.title.tag")}</title>
+			</Helmet>
+			Privacy Policy
+		</Container>
+	)
 }
 
 export default PrivacyPolicy

--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -1,12 +1,29 @@
+import { Helmet } from "react-helmet-async"
+
 import useIntlMessages from "hooks/useIntlMessages"
 import Container from "ui/Container/Container"
+import imageLinkPreview from "../../assets/images/image-link-preview.webp"
 
 const TermsOfService: React.FC = () => {
 	const intl = useIntlMessages()
 
 	return (
 		<Container size="sm">
-			<h2>{intl("terms.of.services.title")}</h2>
+			<Helmet prioritizeSeoTags>
+				<meta
+					name="description"
+					lang="en"
+					content="Details on the use of our services."
+				/>
+				<meta
+					name="description"
+					lang="es"
+					content="Detalles sobre el uso de nuestros servicios."
+				/>
+				<meta property="og:image" content={imageLinkPreview} />
+				<title>{intl("terms.of.service.title.tag")}</title>
+			</Helmet>
+			<h2>{intl("terms.of.service.title")}</h2>
 			<div>
 				<p>
 					The following Terms and Conditions govern the use of each of the websites


### PR DESCRIPTION
# Trim description metadata for all pages

## Summary

Trim the page description metadata to make it look better, and change "page.tab.title" to "page.title.tag" so it makes sense where the page title information is loaded.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [ ] Styling
- [ ] Testing
- [x] Chore
- [ ] Other: ...

## Checklist:

These items must be completed before the code review

- [x] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [x] Check task requirements on Monday or Sprint Planning sheet
