### PR TITLE
fix: correct i18n key for 404 page title in English

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -373,7 +373,7 @@
 	"contact.us.form.toast.success": "Sent successfully",
 	"contact.us.form.toast.error": "Error, try again",
 
-	"page.not.found..title.tag": "Page not found",
+	"page.not.found.title.tag": "Page not found",
 	"page.not.found.tab.title": "Page not found",
 	"page.not.found.title": "Oops!",
 	"page.not.found.sub.title": "I think you got lost...",


### PR DESCRIPTION
# Fix correct i18n key for 404 page title in English

## Summary

### Problem
- The 404 page title isn't translated into English

### Cause
- Someone put a colon instead of a 1 in the en.json key

### Solution
- Remove one of those colons

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [ ] Styling
- [ ] Testing
- [ ] Chore
- [ ] Other: ...

## Checklist:

These items must be completed before the code review

- [x] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [x] Check task requirements on Monday or Sprint Planning sheet
