### PR TITLE
feat: allow null value in attachments field and include design descri…

### DIFF
--- a/src/components/Forms/ComplaintsBookForm/ComplaintsBookForm.schema.ts
+++ b/src/components/Forms/ComplaintsBookForm/ComplaintsBookForm.schema.ts
@@ -51,7 +51,7 @@ export const validationSchemas = [
 		detailsOfTheRequest: Yup.string()
 			.required(VALIDATION_MESSAGE)
 			.min(6, MIN_6_STR_MESSAGE),
-		attachedFile: Yup.mixed(),
+		attachedFile: Yup.mixed().nullable(),
 		orderDetails: Yup.string()
 			.required(VALIDATION_MESSAGE)
 			.min(6, MIN_6_STR_MESSAGE),

--- a/src/components/Forms/ComplaintsBookForm/ComplaintsBookForm.styles.ts
+++ b/src/components/Forms/ComplaintsBookForm/ComplaintsBookForm.styles.ts
@@ -193,6 +193,19 @@ export const RequestType = styled.div`
 	}
 `
 
+export const UploadDescription = styled.div`
+	display: flex;
+	gap: 0.75rem;
+	align-items: baseline;
+
+	& .icon-info {
+		flex-shrink: 0;
+		font-size: 1rem;
+		color: ${colors.tertiary.normal[700]};
+		margin-top: 0.25rem;
+	}
+`
+
 export const InformationDetails = styled.div`
 	display: flex;
 	text-align: left;

--- a/src/components/Forms/ComplaintsBookForm/DetailsForm.tsx
+++ b/src/components/Forms/ComplaintsBookForm/DetailsForm.tsx
@@ -13,6 +13,7 @@ import H5 from "ui/Titles/H5"
 import Input from "ui/input/Input"
 import { requestDetails, services } from "./ComplaintsBookForm.data"
 import { RequestDetails, RequestType } from "./ComplaintsBookForm.styles"
+import { UploadDescription } from "./ComplaintsBookForm.styles"
 import type { InitialValuesType } from "./ComplaintsBookForm.types"
 
 type Props = {
@@ -128,6 +129,12 @@ const DetailsForm: React.FC<Props> = ({ formik }) => {
 						label={intl("complaints.book.form.input.attached.file")}
 						onFileChange={handleFileChange}
 					/>
+					<UploadDescription>
+						<CgInfo className="icon-info" />
+						<Paragraph>
+							{intl("complaints.book.form.input.attached.file.description")}
+						</Paragraph>
+					</UploadDescription>
 					<Textarea
 						id="orderDetails"
 						name="orderDetails"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -437,6 +437,7 @@
 	"complaints.book.form.select.request.type.complaint.description": "If you experienced any discomfort or dissatisfaction during your interaction with our service.",
 	"complaints.book.form.input.request.details": "Request details",
 	"complaints.book.form.input.attached.file": "Attached file",
+	"complaints.book.form.input.attached.file.description": "You can attach photos, screenshots, or other documents to support your claim or complaint.",
 	"complaints.book.form.input.order.details": "Order details",
 	"complaints.book.form.info.description": "For your security, the response to your request will be sent to the email address or physical address you provided.",
 	"complaints.book.form.fieldset.contact.info": "Contact information",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -436,6 +436,7 @@
 	"complaints.book.form.select.request.type.complaint.description": "Cuando sentiste alguna molestia o descontento al momento de recibirnuestra atención.",
 	"complaints.book.form.input.request.details": "Detalle del reclamo o queja",
 	"complaints.book.form.input.attached.file": "Adjuntar archivo",
+	"complaints.book.form.input.attached.file.description": "Puedes adjuntar fotos, capturas u otros documentos que respalden tu reclamo o queja.",
 	"complaints.book.form.input.order.details": "Detalle de la orden",
 	"complaints.book.form.info.description": "Por tu seguridad, la respuesta a tu solicitud será enviada al correo electrónico o dirección física brindada.",
 	"complaints.book.form.fieldset.contact.info": "Información de contacto",


### PR DESCRIPTION
# Allow null value in attachments field and include design description in complaint form

## Summary
- Allow null value in attachments field and include design description in complaint form
- Resution of QA

| DOC | DATE | N° |
|-------|-------|-----|
| [link](https://docs.google.com/document/d/1L4SmxMAtB8RQAPszQTr3BVSaxdlm9vCCO6ZqxhUJaPM/edit?tab=t.0) | 02 - Julio - 2025 | `0001` |

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [x] Styling
- [ ] Testing
- [ ] Chore
- [ ] Other: ...

## Checklist:

These items must be completed before the code review

- [x] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [x] Check task requirements on Monday or Sprint Planning sheet