### PR TITLE
feat: make select dropdown open on click instead of hover

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -84,14 +84,6 @@ const Select: React.FC<Props> = ({
 		}
 	}, [open, options])
 
-	const handleMouseEnter = () => {
-		setOpen(true)
-	}
-
-	const handleMouseLeave = () => {
-		setOpen(false)
-	}
-
 	const handleChange = (option: OptionType) => {
 		setOption(option)
 		setOpen(false)
@@ -99,17 +91,17 @@ const Select: React.FC<Props> = ({
 	}
 
 	const handleBlur = () => {
-		onBlur?.()
+		const time = setTimeout(() => {
+			onBlur?.()
+			setOpen(false)
+		}, 100)
+
+		return () => clearTimeout(time)
 	}
 
 	return (
 		<>
-			<SelectWrapper
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
-				tabIndex={0}
-				onBlur={handleBlur}
-			>
+			<SelectWrapper tabIndex={0} onBlur={handleBlur}>
 				<SelectContainer
 					ref={containerRef}
 					$open={open}


### PR DESCRIPTION
# Make select dropdown open on click instead of hover

## Summary
- Make select dropdown open on click instead of hover
- Resolution of QA

| DOC | DATE | OBSERVATION |
|-------|-------|------------------|
| [view](https://docs.google.com/document/d/1L4SmxMAtB8RQAPszQTr3BVSaxdlm9vCCO6ZqxhUJaPM/edit?tab=t.0) | 02-July-2025 | `05` | 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor
- [ ] Styling
- [ ] Testing
- [ ] Chore
- [ ] Other: ...

## Checklist:

These items must be completed before the code review

- [x] Check that branch is pointing to production environment
- [x] Remove console.logs
- [x] Check imports format
- [x] Check variables destructure
- [x] Check docs
- [x] Review the entire pull request yourself before sending it to the reviewer
- [x] Check task requirements on Monday or Sprint Planning sheet